### PR TITLE
chore(build): Install npm 2.x instead of 2.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ notifications:
     skip_join: false
 
 before_install:
-  # Update npm to 2.4
-  - npm install -g npm@2.4
+  # Update npm to 2.x
+  - npm install -g npm@2
 
 install:
   - travis_retry npm install --silent


### PR DESCRIPTION
This allows node v0.12.x to use the most recent version instead of downgrading.

@pdehaan, @TDA - r?
