### PR TITLE
feature(easteregg): Don't display when not running in top-level window.

### DIFF
--- a/src/easteregg.js
+++ b/src/easteregg.js
@@ -25,6 +25,10 @@ var easterEgg = (function (easterEgg) {
   };
   easterEgg.shouldShowEasterEgg = function (windowMock) {
     var win = windowMock || window;
+    // Don't show in contexts where `easterEgg.disableEasterEgg()` wont work.
+    if (win.top !== win.self) {
+      return false;
+    }
     try {
       return (win.localStorage.getItem(STORAGE_NAMESPACE) !== 'false');
     } catch (e) {

--- a/tests/easteregg_test.js
+++ b/tests/easteregg_test.js
@@ -25,12 +25,18 @@ var assert = chai.assert;
     }
   };
 
+  function resetWindow() {
+    window.localStorage.clear();
+    window.self = window;
+    window.top = window.self;
+  }
+
   describe('EasterEgg', function(){
     var STORAGE_NAMESPACE = easterEgg.STORAGE_NAMESPACE;
     describe('#enableEasterEgg()', function(){
-      // clear storage before every test, as otherwise the order of tests would matter
+      // reset state before every test, as otherwise the order of tests would matter
       beforeEach(function() {
-        window.localStorage.clear();
+        resetWindow();
       });
 
       it('should return true when the easter egg is set', function(){
@@ -45,9 +51,9 @@ var assert = chai.assert;
     });
 
     describe('#disableEasterEgg()', function(){
-      // clear storage before every test, as otherwise the order of tests would matter
+      // reset state before every test, as otherwise the order of tests would matter
       beforeEach(function() {
-        window.localStorage.clear();
+        resetWindow();
       });
 
       it('should return false when the easter egg is disabled', function(){
@@ -61,8 +67,18 @@ var assert = chai.assert;
     });
 
     describe('#shouldShowEasterEgg()', function(){
+      // reset state before every test, as otherwise the order of tests would matter
+      beforeEach(function() {
+        resetWindow();
+      });
+
       it('should return a boolean', function(){
         assert.isBoolean(easterEgg.shouldShowEasterEgg(window));
+      });
+
+      it('should return false when not in top-level window', function(){
+        window.self = {};
+        assert.equal(false, easterEgg.shouldShowEasterEgg(window));
       });
     });
   });

--- a/tests/easteregg_test_nostubs.js
+++ b/tests/easteregg_test_nostubs.js
@@ -3,6 +3,7 @@ describe('EasterEgg', function(){
   var STORAGE_NAMESPACE = easterEgg.STORAGE_NAMESPACE;
   beforeEach(function(){
     localStorage.clear();
+    window.self = window;
   });
 
   describe('#enableEasterEgg()', function(){
@@ -30,6 +31,10 @@ describe('EasterEgg', function(){
   describe('#shouldShowEasterEgg()', function(){
     it('should return a boolean', function(){
       assert.isBoolean(easterEgg.shouldShowEasterEgg());
+    });
+    it('should return false when not in top-level window', function(){
+      window.self = {};
+      assert.equal(false, easterEgg.shouldShowEasterEgg());
     });
   });
 });


### PR DESCRIPTION
If we're not in the top-level window, it's hard to disable to easter-egg following its printed instructions, which looks bad.  Fixes https://github.com/mozilla/fxa-content-server/issues/3483
